### PR TITLE
[feature] ETH address -> ONE address converter + Small Bugfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dmypy.json
 
 # IDE
 .idea
+
+# VIM
+*.swp

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ dev:
 	python3 -m pip install pytest-ordering
 
 test:
-	python3 -m py.test -r s -s tests
+	python3 -m pytest -r s -s tests
 
 install:
 	python3 -m pip install -e .

--- a/pyhmy/util.py
+++ b/pyhmy/util.py
@@ -22,6 +22,7 @@ from .account import (
 
 from .bech32.bech32 import (
     bech32_decode,
+    bech32_encode,
     convertbits
 )
 
@@ -96,6 +97,16 @@ def convert_one_to_hex(addr):
     address = '0x' + ''.join('{:02x}'.format(x) for x in buf)
     return to_checksum_address(address)
 
+def convert_hex_to_one(addr):
+    """
+    Given a hex address, convert it to a one address
+    """
+    if is_valid_address(addr):
+        return addr
+    checksum_addr = to_checksum_address(addr)
+    data = bytearray.fromhex(checksum_addr[2:] if checksum_addr.startswith("0x") else checksum_addr)
+    buf = convertbits(data, 8, 5)
+    return bech32_encode("one", buf)
 
 def is_active_shard(endpoint, delay_tolerance=60):
     """

--- a/tests/bech32-pyhmy/test_bech32.py
+++ b/tests/bech32-pyhmy/test_bech32.py
@@ -7,3 +7,4 @@ def test_encode():
 
 def test_decode():
     bech32.decode('one', 'one1a0x3d6xpmr6f8wsyaxd9v36pytvp48zckswvv9')
+

--- a/tests/util-pyhmy/test_util.py
+++ b/tests/util-pyhmy/test_util.py
@@ -47,6 +47,11 @@ def test_convert_one_to_hex():
     assert util.convert_one_to_hex('0xebcd16e8c1d8f493ba04e99a56474122d81a9c58') == '0xeBCD16e8c1D8f493bA04E99a56474122D81A9c58'
     assert util.convert_one_to_hex('one1a0x3d6xpmr6f8wsyaxd9v36pytvp48zckswvv9') == '0xeBCD16e8c1D8f493bA04E99a56474122D81A9c58'
 
+def test_convert_hex_to_one():
+    assert util.convert_hex_to_one('0xebcd16e8c1d8f493ba04e99a56474122d81a9c58') == 'one1a0x3d6xpmr6f8wsyaxd9v36pytvp48zckswvv9'
+    assert util.convert_hex_to_one('one1a0x3d6xpmr6f8wsyaxd9v36pytvp48zckswvv9') == 'one1a0x3d6xpmr6f8wsyaxd9v36pytvp48zckswvv9'
+    
+
 def test_get_bls_build_variables():
     assert isinstance(util.get_bls_build_variables(), dict)
 


### PR DESCRIPTION
- added `convert_hex_to_one` function in `util.py` with unit test (addresses #29)
- added `__init__.py` to bech32 module, resolves issues #33 #31 #26 
- fixed `make test` command in Makefile
- added vim `.swp` files to gitignore