### PR TITLE
fix(signing): drop shard ids from serializer

### DIFF
--- a/pyhmy/__init__.py
+++ b/pyhmy/__init__.py
@@ -4,7 +4,7 @@
 import sys
 import warnings
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 if sys.version_info.major < 3:
     warnings.simplefilter( "always", DeprecationWarning )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyhmy"
-version = "0.1.0"
+version = "0.1.1"
 description = "A library for interacting and working the Harmony blockchain and related codebases"
 readme = "README.md"
 license = { text = "MIT" }
@@ -26,7 +26,7 @@ requires-python = ">=3.0"
 dev = [ "black", "autopep8", "yapf", "twine", "build", "docformatter", "bumpver" ]
 
 [tool.bumpver]
-current_version = "0.1.0"
+current_version = "0.1.1"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "chore: bump version {old_version} -> {new_version}"
 # git commit --amend -S

--- a/tests/sdk-pyhmy/test_signing.py
+++ b/tests/sdk-pyhmy/test_signing.py
@@ -98,3 +98,23 @@ def test_hmy_transaction():
         signed_tx.rawTransaction.hex() ==
         "0xf85f02016480019414791697260e4c9a71f18484c9f997b308e59325058026a02a203357ca6d7cdec981ad3d3692ad2c9e24536a9b6e7b486ce2f94f28c7563ea010d38cd0312a153af0aa7d8cd986040c36118bba373cb94e3e86fd4aedce904d"
     )
+
+def test_hmy_eth_compatible_transaction():
+    transaction_dict = {
+        "chainId": 1666600000,
+        "gas": 21000,
+        "gasPrice": 100000000000,
+        "nonce": 0,
+        "shardID": 0,
+        "to": "0x19e7e376e7c213b7e7e7e46cc70a5dd086daff2a",
+        "toShardID": 1,
+        "value": 1000000000000000000
+    }
+    signed_tx = signing.sign_transaction(
+        transaction_dict,
+        "0x1111111111111111111111111111111111111111111111111111111111111111",
+    )
+    assert (
+        signed_tx.rawTransaction.hex() ==
+        "0xf8728085174876e80082520880019419e7e376e7c213b7e7e7e46cc70a5dd086daff2a880de0b6b3a76400008084c6ac98a3a0322cca082c3ca0a1d9ad5fffb4dc0e09ade49b4b0e3b0c9dfa5f6288bc7363d6a05604874964abaaf364e8b10108e8bfed5561c341aa5e4abb92b2c6f4c009ef4c"
+    )


### PR DESCRIPTION
Similar to how the Go node and the Go SDK do it, drop the `ShardID` and `ToShardID` from the serialization if the `chainId` is reported to be larger than the mainnet Ethereum compatible chainId.