### PR TITLE
fix(signing): do not drop shardID for rlp encoding

### DIFF
--- a/pyhmy/__init__.py
+++ b/pyhmy/__init__.py
@@ -4,7 +4,7 @@
 import sys
 import warnings
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 if sys.version_info.major < 3:
     warnings.simplefilter( "always", DeprecationWarning )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyhmy"
-version = "0.1.1"
+version = "0.1.2"
 description = "A library for interacting and working the Harmony blockchain and related codebases"
 readme = "README.md"
 license = { text = "MIT" }
@@ -26,7 +26,7 @@ requires-python = ">=3.0"
 dev = [ "black", "autopep8", "yapf", "twine", "build", "docformatter", "bumpver" ]
 
 [tool.bumpver]
-current_version = "0.1.1"
+current_version = "0.1.2"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "chore: bump version {old_version} -> {new_version}"
 # git commit --amend -S

--- a/tests/sdk-pyhmy/test_signing.py
+++ b/tests/sdk-pyhmy/test_signing.py
@@ -99,6 +99,7 @@ def test_hmy_transaction():
         "0xf85f02016480019414791697260e4c9a71f18484c9f997b308e59325058026a02a203357ca6d7cdec981ad3d3692ad2c9e24536a9b6e7b486ce2f94f28c7563ea010d38cd0312a153af0aa7d8cd986040c36118bba373cb94e3e86fd4aedce904d"
     )
 
+
 def test_hmy_eth_compatible_transaction():
     transaction_dict = {
         "chainId": 1666600000,
@@ -108,7 +109,8 @@ def test_hmy_eth_compatible_transaction():
         "shardID": 0,
         "to": "0x19e7e376e7c213b7e7e7e46cc70a5dd086daff2a",
         "toShardID": 1,
-        "value": 1000000000000000000
+        "value": 1000000000000000000,
+        "data": "0xabcd",
     }
     signed_tx = signing.sign_transaction(
         transaction_dict,
@@ -116,5 +118,5 @@ def test_hmy_eth_compatible_transaction():
     )
     assert (
         signed_tx.rawTransaction.hex() ==
-        "0xf8728085174876e80082520880019419e7e376e7c213b7e7e7e46cc70a5dd086daff2a880de0b6b3a76400008084c6ac98a3a0322cca082c3ca0a1d9ad5fffb4dc0e09ade49b4b0e3b0c9dfa5f6288bc7363d6a05604874964abaaf364e8b10108e8bfed5561c341aa5e4abb92b2c6f4c009ef4c"
+        "0xf8748085174876e80082520880019419e7e376e7c213b7e7e7e46cc70a5dd086daff2a880de0b6b3a764000082abcd84c6ac98a4a0ef05b0bc0827ddd046ee8196253c6609484e28b8f250d860736ce8e053469f04a07229a88ce68241a9e77dcb1592a67a9a6a215d855a784467c9f550f8c4cb9b76"
     )

--- a/tests/sdk-pyhmy/test_signing.py
+++ b/tests/sdk-pyhmy/test_signing.py
@@ -99,7 +99,17 @@ def test_hmy_transaction():
         "0xf85f02016480019414791697260e4c9a71f18484c9f997b308e59325058026a02a203357ca6d7cdec981ad3d3692ad2c9e24536a9b6e7b486ce2f94f28c7563ea010d38cd0312a153af0aa7d8cd986040c36118bba373cb94e3e86fd4aedce904d"
     )
 
-
+# ./hmy transfer --offline-sign \
+# --nonce 0 \
+# --from one1r8n7xah8cgfm0el8u3kvwzja6zrd4le2ntjy82 \
+# --to one1r8n7xah8cgfm0el8u3kvwzja6zrd4le2ntjy82 \
+# --amount 1 \
+# --gas-limit 21000 \
+# --gas-price 100 \
+# --from-shard 0 \
+# --to-shard 1 \
+# --chain-id 1666600000 \
+# --data 0xabcd
 def test_hmy_eth_compatible_transaction():
     transaction_dict = {
         "chainId": 1666600000,


### PR DESCRIPTION
This change only impacts `chainId >= 1666600000`.