### PR TITLE
fix(test): test_get_elected_validator_addresses - wait until for the next epoch

### DIFF
--- a/pyhmy/util.py
+++ b/pyhmy/util.py
@@ -111,7 +111,7 @@ def convert_hex_to_one( addr ):
     return str( bech32_encode( "one", buf ) )
 
 
-def is_active_shard( endpoint, delay_tolerance = 60 ):
+def is_active_shard(endpoint, delay_tolerance=60):
     """
     :param endpoint: The endpoint of the SHARD to check
     :param delay_tolerance: The time (in seconds) that the shard timestamp can be behind
@@ -119,15 +119,14 @@ def is_active_shard( endpoint, delay_tolerance = 60 ):
     """
     try:
         curr_time = datetime.datetime.now(datetime.UTC)
-        latest_header = get_latest_header( endpoint = endpoint )
-        time_str = latest_header[ "timestamp" ][ : 19 ] + ".0"  # Fit time format
+        latest_header = get_latest_header(endpoint=endpoint)
+        time_str = latest_header["timestamp"][:19] + ".0"  # Fit time format
         timestamp = datetime.datetime.strptime(
-            time_str,
-            "%Y-%m-%d %H:%M:%S.%f"
-        ).replace( tzinfo = None )
+            time_str, "%Y-%m-%d %H:%M:%S.%f"
+        ).replace(tzinfo=datetime.UTC)
         time_delta = curr_time - timestamp
-        return abs( time_delta.seconds ) < delay_tolerance
-    except ( RPCError, RequestsError, RequestsTimeoutError ):
+        return abs(time_delta.total_seconds()) < delay_tolerance
+    except (RPCError, RequestsError, RequestsTimeoutError):
         return False
 
 

--- a/tests/sdk-pyhmy/test_staking.py
+++ b/tests/sdk-pyhmy/test_staking.py
@@ -1,5 +1,5 @@
 import pytest
-import requests
+import time
 
 from pyhmy import staking
 
@@ -120,9 +120,19 @@ def test_get_delegations_by_delegator_by_block( setup_blockchain ):
 
 
 def test_get_elected_validator_addresses():
-    validator_addresses = _test_staking_rpc(
-        staking.get_elected_validator_addresses
-    )
+    timeout = 300
+    check_interval = 10
+    start_time = time.time()
+
+    while True:
+        validator_addresses = _test_staking_rpc(
+            staking.get_elected_validator_addresses
+        )
+        if isinstance(validator_addresses, list) and len(validator_addresses) > 0:
+            break
+        if time.time() - start_time > timeout:
+            pytest.fail("Timed out waiting for elected validators")
+        time.sleep(check_interval)
     assert isinstance( validator_addresses, list )
     assert len( validator_addresses ) > 0
 


### PR DESCRIPTION
What was done:
* simple waiter for the elected validators aka wait for next epoch
* unify timestamps in the fix is_active_shard

Link to the successful run:
* https://app.travis-ci.com/github/harmony-one/harmony/jobs/632725924