### PR TITLE
refactor: point negative scenarios to our domain instead of example.com

### DIFF
--- a/tests/sdk-pyhmy/test_account.py
+++ b/tests/sdk-pyhmy/test_account.py
@@ -11,7 +11,7 @@ local_test_address = "one155jp2y76nazx8uw5sa94fr0m4s5aj8e5xm6fu3"
 test_validator_address = local_test_address
 genesis_block_number = 0
 test_block_number = 1
-fake_shard = "http://example.com"
+fake_shard = "https://faucet.pops.one/"
 
 
 def _test_account_rpc( fn, *args, **kwargs ):

--- a/tests/sdk-pyhmy/test_blockchain.py
+++ b/tests/sdk-pyhmy/test_blockchain.py
@@ -9,7 +9,7 @@ test_epoch_number = 0
 genesis_block_number = 0
 test_block_number = 1
 test_block_hash = None
-fake_shard = "http://example.com"
+fake_shard = "https://faucet.pops.one/"
 address = "one155jp2y76nazx8uw5sa94fr0m4s5aj8e5xm6fu3"
 
 

--- a/tests/sdk-pyhmy/test_contract.py
+++ b/tests/sdk-pyhmy/test_contract.py
@@ -9,7 +9,7 @@ contract_tx_hash = "0xa605852dd2fa39ed42e101c17aaca9d344d352ba9b24b14b9af94ec9cb
 # deployedBytecode from json file
 contract_code = "0x6080604052348015600f57600080fd5b506004361060285760003560e01c80634936cd3614602d575b600080fd5b604080516001815290519081900360200190f3fea2646970667358221220fa3fa0e8d0267831a59f4dd5edf39a513d07e98461cb06660ad28d4beda744cd64736f6c634300080f0033"
 contract_address = None
-fake_shard = "http://example.com"
+fake_shard = "https://faucet.pops.one/"
 
 
 def _test_contract_rpc( fn, *args, **kwargs ):

--- a/tests/sdk-pyhmy/test_staking.py
+++ b/tests/sdk-pyhmy/test_staking.py
@@ -7,7 +7,7 @@ from pyhmy.rpc import exceptions
 
 explorer_endpoint = "http://localhost:9620"
 test_validator_address = "one155jp2y76nazx8uw5sa94fr0m4s5aj8e5xm6fu3"
-fake_shard = "http://example.com"
+fake_shard = "https://faucet.pops.one/"
 
 
 def _test_staking_rpc( fn, *args, **kwargs ):

--- a/tests/sdk-pyhmy/test_transaction.py
+++ b/tests/sdk-pyhmy/test_transaction.py
@@ -6,7 +6,7 @@ from pyhmy.rpc import exceptions
 
 endpoint = "http://localhost:9620"
 endpoint_shard_one = "http://localhost:9622"
-fake_shard = "http://example.com"
+fake_shard = "https://faucet.pops.one/"
 
 # previously sent txs to get and check
 tx_hash = "0xc26be5776aa57438bccf196671a2d34f3f22c9c983c0f844c62b2fb90403aa43"


### PR DESCRIPTION
What was done:
* debug of the issue - CI tests duration doubled or sometimes tests started to fail
* reason - example.com started to exponentially throttle connections causing our tests to run for 40 minutes instead of 15
Proof: 
On the third curl time was real	1m14.862s, on the forth real 2m14.862s, and so on
* pointed to the domain controlled by us and tests started to run locally for 2m3.398s, same result + time on the setup should be in the CI

Local run: 
130 passed in 122.74s (0:02:02) 
