### PR TITLE
fix: return total supply RPC result

### DIFF
--- a/pyhmy/blockchain.py
+++ b/pyhmy/blockchain.py
@@ -718,9 +718,9 @@ def get_total_supply(
     """
     method = "hmyv2_getTotalSupply"
     try:
-        rpc_request( method,
-                     endpoint = endpoint,
-                     timeout = timeout )[ "result" ]
+        return rpc_request( method,
+                            endpoint = endpoint,
+                            timeout = timeout )[ "result" ]
     except KeyError as exception:
         raise InvalidRPCReplyError( method, endpoint ) from exception
 

--- a/tests/request-pyhmy/test_blockchain_return_values.py
+++ b/tests/request-pyhmy/test_blockchain_return_values.py
@@ -1,0 +1,13 @@
+from pyhmy import blockchain
+
+
+def test_get_total_supply_returns_rpc_result( monkeypatch ):
+    expected = "15260238647.49999999480981481"
+
+    def mock_rpc_request( method, endpoint = None, timeout = None ):
+        assert method == "hmyv2_getTotalSupply"
+        return { "result": expected }
+
+    monkeypatch.setattr( blockchain, "rpc_request", mock_rpc_request )
+
+    assert blockchain.get_total_supply() == expected


### PR DESCRIPTION
## Summary
- Return the `hmyv2_getTotalSupply` RPC result from `blockchain.get_total_supply()`.
- Add a regression test that mocks the RPC response and verifies the function no longer returns `None` when `result` is present.

## Why
`get_total_supply()` indexed the `result` field but missed the `return` statement. This made the SDK return `None` even when the endpoint provided a valid total supply string.

This is a small contribution toward harmony-one/bounties#7, specifically the acceptance criterion to check unexpected `None` return types for RPCs and add unit coverage.

## Validation
- `python3 -m py_compile pyhmy/blockchain.py tests/request-pyhmy/test_blockchain_return_values.py`
- `python3 -m pytest -q tests/request-pyhmy/test_blockchain_return_values.py`
- Manual public RPC check: `blockchain.get_total_supply(endpoint="https://api.s0.t.hmny.io")` returns a total supply string.
